### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+filters:
+  .*:
+    approvers:
+    - cynepco3hahue
+    - fromanirh
+    - marsik
+    - swatisehgal
+    - tal-or
+    - yanirq
+    reviewers:
+    - cynepco3hahue
+    - fromanirh
+    - marsik
+    - swatisehgal
+    - tal-or
+    - yanirq
+options: {}


### PR DESCRIPTION
The approvers/reviewers list is open for changes.
At the moment we need this OWNERS file in order to set-up the OpenShift's CI which required a valid OWNERS file.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>