### PR TITLE
Dockerfile: u/s alignment of the entrypoint

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,3 +1,3 @@
 FROM  quay.io/centos/centos:centos7.9.2009
-ADD _out/resource-topology-exporter /usr/local/bin/resource-topology-exporter
-ENTRYPOINT ["/usr/local/bin/resource-topology-exporter"]
+ADD _out/resource-topology-exporter /bin/resource-topology-exporter
+ENTRYPOINT ["/bin/resource-topology-exporter"]


### PR DESCRIPTION
Let's use the same entrypoint (and binary location) as u/s.
Otherwise we will have an unnecessary difference in the kubernetes
manifests, because we will need to handle different entry points
depending on the image location (e.g. images from the same sources
are unnecessarily incompatible with each other)

Signed-off-by: Francesco Romani <fromani@redhat.com>