### PR TITLE
Emulate GetAllocatableResources if not available

### DIFF
--- a/config/examples/resources.json
+++ b/config/examples/resources.json
@@ -1,0 +1,6 @@
+{
+	"reserved_cpus": "0,12",
+	"resource_mapping": {
+		"8086:1520": "intel_sriov_netdevice"
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,13 @@ go 1.16
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
+	github.com/jaypipes/pcidb v0.6.0
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.0.0-20210729184402-806588edb85b
+	google.golang.org/grpc v1.35.0
+	k8s.io/kubelet v0.21.0
+	k8s.io/kubernetes v1.21.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 // The k8s "sub-"packages do not have 'semver' compatible versions. Thus, we

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,3 +1,6 @@
 FROM  quay.io/centos/centos:centos7.9.2009
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
+RUN mkdir /etc/resource-topology-exporter-config/
+# initialize with empty content
+RUN echo "{}" > /etc/resource-topology-exporter-config/resources.json
 ENTRYPOINT ["/bin/resource-topology-exporter"]

--- a/pkg/podrescompat/client.go
+++ b/pkg/podrescompat/client.go
@@ -1,0 +1,83 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podrescompat
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/openshift-kni/resource-topology-exporter/pkg/sysinfo"
+)
+
+type sysinfoClient struct {
+	sysInfoConfig string
+	cli           podresourcesapi.PodResourcesListerClient
+}
+
+func NewSysinfoClientFromLister(cli podresourcesapi.PodResourcesListerClient, sysInfoConfig string) (podresourcesapi.PodResourcesListerClient, error) {
+	return &sysinfoClient{
+		cli:           cli,
+		sysInfoConfig: sysInfoConfig,
+	}, nil
+}
+
+func (sc *sysinfoClient) List(ctx context.Context, in *podresourcesapi.ListPodResourcesRequest, opts ...grpc.CallOption) (*podresourcesapi.ListPodResourcesResponse, error) {
+	return sc.cli.List(ctx, in, opts...)
+}
+
+func (sc *sysinfoClient) GetAllocatableResources(ctx context.Context, in *podresourcesapi.AllocatableResourcesRequest, opts ...grpc.CallOption) (*podresourcesapi.AllocatableResourcesResponse, error) {
+	resp, err := sc.cli.GetAllocatableResources(ctx, in, opts...)
+	if err != nil {
+		sysResp, sysErr := sc.makeAllocatableResourcesResponse()
+		if sysErr != nil {
+			// TODO: log sysErr, but bubble up the original error, as our internal error is not part of the podresources API
+			return resp, err
+		}
+		return sysResp, nil
+	}
+	return resp, nil
+}
+
+func (sc *sysinfoClient) makeAllocatableResourcesResponse() (*podresourcesapi.AllocatableResourcesResponse, error) {
+	sysInfo, err := sysinfo.NewSysinfo(sc.sysInfoConfig)
+	if err != nil {
+		return nil, err
+	}
+	return MakeAllocatableResourcesResponseFromSysInfo(sysInfo), nil
+}
+
+func MakeAllocatableResourcesResponseFromSysInfo(sysInfo sysinfo.SysInfo) *podresourcesapi.AllocatableResourcesResponse {
+	resp := podresourcesapi.AllocatableResourcesResponse{
+		CpuIds: sysInfo.CPUs.ToSliceInt64(),
+	}
+	for resourceName, resourceDevices := range sysInfo.Resources {
+		for numaCellID, numaDevices := range resourceDevices {
+			cntDevs := podresourcesapi.ContainerDevices{
+				ResourceName: resourceName,
+				DeviceIds:    numaDevices,
+				Topology: &podresourcesapi.TopologyInfo{
+					Nodes: []*podresourcesapi.NUMANode{
+						&podresourcesapi.NUMANode{ID: int64(numaCellID)},
+					},
+				},
+			}
+			resp.Devices = append(resp.Devices, &cntDevs)
+		}
+	}
+	return &resp
+}

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,0 +1,171 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/jaypipes/ghw/pkg/pci"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+const (
+	SysDevicesOnlineCPUs = "/sys/devices/system/cpu/online"
+)
+
+type Config struct {
+	ReservedCPUs string `json:"reserved_cpus"`
+	// vendor:device -> resourcename
+	ResourceMapping map[string]string `json:"resource_mapping"`
+}
+
+// NUMA Cell -> deviceIDs
+type PerNUMADevices map[int][]string
+
+type SysInfo struct {
+	CPUs cpuset.CPUSet
+	// resource name -> devices
+	Resources map[string]PerNUMADevices
+}
+
+func (si SysInfo) String() string {
+	b := strings.Builder{}
+	fmt.Fprintf(&b, "cpus: %s\n", si.CPUs.String())
+	for resourceName, numaDevs := range si.Resources {
+		fmt.Fprintf(&b, "resource %q:\n", resourceName)
+		for numaNode, devs := range numaDevs {
+			fmt.Fprintf(&b, "  numa cell %d -> %v\n", numaNode, devs)
+		}
+	}
+	return b.String()
+}
+
+func NewSysinfo(configFile string) (SysInfo, error) {
+	sysinfo := SysInfo{}
+	conf, err := readConfig(configFile)
+	if err != nil {
+		return sysinfo, err
+	}
+	log.Printf("conf: received: %+#v", conf)
+
+	sysinfo.CPUs, err = GetCPUResources(conf.ReservedCPUs, GetOnlineCPUs)
+	if sysinfo.CPUs.Size() == 0 {
+		return sysinfo, fmt.Errorf("no allocatable cpus")
+	}
+
+	sysinfo.Resources, err = GetPCIResources(conf.ResourceMapping, GetPCIDevices)
+	if err != nil {
+		return sysinfo, err
+	}
+	return sysinfo, nil
+}
+
+func GetCPUResources(resCPUs string, getCPUs func() (cpuset.CPUSet, error)) (cpuset.CPUSet, error) {
+	reservedCPUs, err := cpuset.Parse(resCPUs)
+	if err != nil {
+		return cpuset.CPUSet{}, err
+	}
+	log.Printf("cpus: reserved %s", reservedCPUs.String())
+
+	cpus, err := getCPUs()
+	if err != nil {
+		return cpuset.CPUSet{}, err
+	}
+	log.Printf("cpus: online %s", cpus.String())
+
+	return cpus.Difference(reservedCPUs), nil
+}
+
+func GetPCIResources(resourceMap map[string]string, getPCIs func() ([]*pci.Device, error)) (map[string]PerNUMADevices, error) {
+	numaResources := make(map[string]PerNUMADevices)
+	devices, err := getPCIs()
+	if err != nil {
+		return numaResources, err
+	}
+
+	for _, dev := range devices {
+		resourceName, ok := ResourceNameForDevice(dev, resourceMap)
+		if !ok {
+			continue
+		}
+
+		numaDevs, ok := numaResources[resourceName]
+		if !ok {
+			numaDevs = make(PerNUMADevices)
+		}
+
+		nodeID := -1
+		if dev.Node != nil {
+			nodeID = dev.Node.ID
+		}
+		numaDevs[nodeID] = append(numaDevs[nodeID], dev.Address)
+		numaResources[resourceName] = numaDevs
+	}
+
+	return numaResources, nil
+}
+
+func ResourceNameForDevice(dev *pci.Device, resourceMap map[string]string) (string, bool) {
+	devID := fmt.Sprintf("%s:%s", dev.Vendor.ID, dev.Product.ID)
+	if resourceName, ok := resourceMap[devID]; ok {
+		log.Printf("devs: resource for %s is %q", devID, resourceName)
+		return resourceName, true
+	}
+	if resourceName, ok := resourceMap[dev.Vendor.ID]; ok {
+		log.Printf("devs: resource for %s is %q", dev.Vendor.ID, resourceName)
+		return resourceName, true
+	}
+	return "", false
+}
+
+func GetOnlineCPUs() (cpuset.CPUSet, error) {
+	data, err := ioutil.ReadFile(SysDevicesOnlineCPUs)
+	if err != nil {
+		return cpuset.CPUSet{}, err
+	}
+	cpus := strings.TrimSpace(string(data))
+	return cpuset.Parse(cpus)
+}
+
+func GetPCIDevices() ([]*pci.Device, error) {
+	info, err := pci.New()
+	if err != nil {
+		return nil, err
+	}
+	return info.Devices, nil
+}
+
+func readConfig(configFile string) (Config, error) {
+	var conf Config
+	src, err := os.Open(configFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("conf: none found")
+			return conf, nil
+		}
+		return conf, err
+	}
+	defer src.Close()
+	err = json.NewDecoder(src).Decode(&conf)
+	log.Printf("conf: decoded: %+#v", conf)
+	return conf, err
+}

--- a/pkg/sysinfo/sysinfo_test.go
+++ b/pkg/sysinfo/sysinfo_test.go
@@ -1,0 +1,155 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jaypipes/ghw/pkg/pci"
+	"github.com/jaypipes/ghw/pkg/topology"
+	"github.com/jaypipes/pcidb"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+func TestGetCPUResources(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		online   string
+		reserved string
+		expected string
+	}{
+		{"no reserved", "0-15", "", "0-15"},
+		{"reserved", "0-15", "0,8", "1-7,9-15"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := GetCPUResources(testCase.reserved, func() (cpuset.CPUSet, error) { return cpuset.Parse(testCase.online) })
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			expectedCPUs := cpuset.MustParse(testCase.expected)
+			if !got.Equals(expectedCPUs) {
+				t.Errorf("got %s, want %s", got, expectedCPUs)
+			}
+		})
+	}
+}
+
+func TestGetPCIResources(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		devs     []*pci.Device
+		resMap   map[string]string
+		expected map[string]PerNUMADevices
+	}{
+		{"no devs", nil, map[string]string{"8086:1520": "intel_nics"}, map[string]PerNUMADevices{}},
+		{
+			"devs no numa",
+			[]*pci.Device{
+				fakePCIDevice("8086", "1520", "0000:00:02.0", -1),
+				fakePCIDevice("8086", "1520", "0000:00:02.1", -1),
+			},
+			map[string]string{"8086:1520": "intel_nics"},
+			map[string]PerNUMADevices{
+				"intel_nics": map[int][]string{
+					-1: []string{"0000:00:02.0", "0000:00:02.1"},
+				},
+			},
+		},
+		{
+			"devs single numa",
+			[]*pci.Device{
+				fakePCIDevice("8086", "1520", "0000:00:02.0", 0),
+				fakePCIDevice("8086", "1520", "0000:00:02.1", 0),
+			},
+			map[string]string{"8086:1520": "intel_nics"},
+			map[string]PerNUMADevices{
+				"intel_nics": map[int][]string{
+					0: []string{"0000:00:02.0", "0000:00:02.1"},
+				},
+			},
+		},
+		{
+			"devs multi numa",
+			[]*pci.Device{
+				fakePCIDevice("8086", "1520", "0000:00:02.0", 0),
+				fakePCIDevice("8086", "1520", "0000:00:03.0", 1),
+			},
+			map[string]string{"8086:1520": "intel_nics"},
+			map[string]PerNUMADevices{
+				"intel_nics": map[int][]string{
+					0: []string{"0000:00:02.0"},
+					1: []string{"0000:00:03.0"},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := GetPCIResources(testCase.resMap, func() ([]*pci.Device, error) { return testCase.devs, nil })
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, testCase.expected) {
+				t.Errorf("got %v, want %v", got, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestResourceNameForDevice(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		dev      *pci.Device
+		resMap   map[string]string
+		expected string
+	}{
+		{"anonymous", namedPCIDevice("", ""), map[string]string{}, ""},
+		{"full match", namedPCIDevice("8086", "1520"), map[string]string{"8086:1520": "intel_nics"}, "intel_nics"},
+		{"vendor match", namedPCIDevice("8086", "1520"), map[string]string{"8086": "intel_nics"}, "intel_nics"},
+		{"full over partial match", namedPCIDevice("8086", "1520"), map[string]string{"8086:1520": "my_nics", "8086": "intel_nics"}, "my_nics"},
+		{"no product match", namedPCIDevice("8086", "1520"), map[string]string{"1520": "my_nics", "8086": "intel_nics"}, "intel_nics"},
+		{"ignore if no resMap", namedPCIDevice("8086", "1520"), map[string]string{}, ""},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, _ := ResourceNameForDevice(testCase.dev, testCase.resMap)
+			if got != testCase.expected {
+				t.Errorf("got %q, want %q", got, testCase.expected)
+			}
+		})
+	}
+}
+
+func namedPCIDevice(vendorID, productID string) *pci.Device {
+	return &pci.Device{
+		Vendor: &pcidb.Vendor{
+			ID: vendorID,
+		},
+		Product: &pcidb.Product{
+			ID: productID,
+		},
+	}
+}
+
+func fakePCIDevice(vendorID, productID, address string, numaNode int) *pci.Device {
+	dev := namedPCIDevice(vendorID, productID)
+	dev.Address = address
+	if numaNode != -1 {
+		dev.Node = &topology.Node{ID: numaNode}
+	}
+	return dev
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,6 +49,7 @@ github.com/googleapis/gnostic/openapiv2
 # github.com/imdario/mergo v0.3.5
 github.com/imdario/mergo
 # github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
+## explicit
 github.com/jaypipes/ghw
 github.com/jaypipes/ghw/pkg/baseboard
 github.com/jaypipes/ghw/pkg/bios
@@ -71,6 +72,7 @@ github.com/jaypipes/ghw/pkg/topology
 github.com/jaypipes/ghw/pkg/unitutil
 github.com/jaypipes/ghw/pkg/util
 # github.com/jaypipes/pcidb v0.6.0
+## explicit
 github.com/jaypipes/pcidb
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
@@ -151,6 +153,7 @@ google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.35.0 => google.golang.org/grpc v1.27.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -426,10 +429,12 @@ k8s.io/component-base/version
 # k8s.io/klog/v2 v2.8.0
 k8s.io/klog/v2
 # k8s.io/kubelet v0.21.0 => k8s.io/kubelet v0.21.0
+## explicit
 k8s.io/kubelet/config/v1beta1
 k8s.io/kubelet/pkg/apis/podresources/v1
 k8s.io/kubelet/pkg/apis/podresources/v1alpha1
 # k8s.io/kubernetes v1.21.0
+## explicit
 k8s.io/kubernetes/pkg/features
 k8s.io/kubernetes/pkg/kubelet/apis/podresources
 k8s.io/kubernetes/pkg/kubelet/cm/cpuset
@@ -444,6 +449,7 @@ sigs.k8s.io/structured-merge-diff/v4/schema
 sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 # golang.org/x/text => golang.org/x/text v0.3.5


### PR DESCRIPTION
 sysinfo: wrap GetAllocatableResources if disabled

The resource topology exporter depends on the full
availability of the podresources API, so with *both*
- List
- GetAllocatableResources

However the latter is feature-gated - being alpha,
and in some environments it could not be enabled,
nor the admin would be willing to enable such feature gate.

It is still worthy to be able to *test* and *benchmark*
RTE in these environments, so for *benchmark purposes*
we add a very limited and very intentionally narrow
emulation of GetAllocatableResources functionality,
reading raw data from the system the same way the kubelet would.

Of course this is intentionally limited and will not
be evolved (barring bugs and extremely simple additions)
because the recommended and supported way is to
just enable the full feature set of the podresources API.