### PR TITLE
sysinfo: wrap GetAllocatableResources if disabled

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -1,3 +1,17 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -16,6 +30,9 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podrescli"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
+
+	"github.com/openshift-kni/resource-topology-exporter/pkg/podrescompat"
+	"github.com/openshift-kni/resource-topology-exporter/pkg/sysinfo"
 )
 
 const (
@@ -23,15 +40,39 @@ const (
 	ProgramName = "resource-topology-exporter"
 )
 
+type localArgs struct {
+	SysInfoConfigFile string
+}
+
 func main() {
-	nrtupdaterArgs, resourcemonitorArgs, rteArgs, err := argsParse(os.Args[1:])
+	nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, err := argsParse(os.Args[1:])
 	if err != nil {
 		log.Fatalf("failed to parse command line: %v", err)
 	}
 
-	cli, err := podrescli.NewFilteringClient(resourcemonitorArgs.PodResourceSocketPath, rteArgs.Debug, rteArgs.ReferenceContainer)
+	// only for debug purposes
+	// printing the header so early includes any debug message from the sysinfo package
+	log.Printf("=== System information ===\n")
+	sysInfo, err := sysinfo.NewSysinfo(localArgs.SysInfoConfigFile)
 	if err != nil {
-		log.Fatalf("failed to get podresources client: %v", err)
+		log.Fatalf("failed to query system info: %v", err)
+	}
+	log.Printf("%s", sysInfo)
+	log.Printf("==========================\n")
+
+	k8sCli, err := podrescli.NewK8SClient(resourcemonitorArgs.PodResourceSocketPath)
+	if err != nil {
+		log.Fatalf("failed to get podresources k8s client: %v", err)
+	}
+
+	sysCli := k8sCli
+	if localArgs.SysInfoConfigFile != "" {
+		sysCli = podrescompat.NewSysinfoClientFromLister(k8sCli, localArgs.SysInfoConfigFile)
+	}
+
+	cli, err := podrescli.NewFilteringClientFromLister(sysCli, rteArgs.Debug, rteArgs.ReferenceContainer)
+	if err != nil {
+		log.Fatalf("failed to get podresources filtering client: %v", err)
 	}
 
 	err = resourcetopologyexporter.Execute(cli, nrtupdaterArgs, resourcemonitorArgs, rteArgs)
@@ -55,6 +96,7 @@ const helpTemplate string = `{{.ProgramName}}
 			[--topology-manager-policy=<pol>]
 			[--reference-container=<spec>]
 			[--exclude-list-config=<path>]
+			[--resource-config=<path>]
 
   {{.ProgramName}} -h | --help
   {{.ProgramName}} --version
@@ -84,7 +126,9 @@ const helpTemplate string = `{{.ProgramName}}
                                   Alternatively, you can use the env vars
 				                  REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.
   --exclude-list-config=<path>    Exclude resources list file path.
-                                  [Default:/etc/resource-topology-exporter-config/exclude-list-config.yaml]`
+                                  [Default: /etc/resource-topology-exporter-config/exclude-list-config.yaml]
+  --resource-config=<path>        Resource Mapping configuration file path.
+                                  [Default: /etc/resource-topology-exporter-config/resources.json]`
 
 func getUsage() (string, error) {
 	var helpBuffer bytes.Buffer
@@ -108,14 +152,15 @@ func getUsage() (string, error) {
 
 // nrtupdaterArgsParse parses the command line arguments passed to the program.
 // The argument argv is passed only for testing purposes.
-func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourcetopologyexporter.Args, error) {
+func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourcetopologyexporter.Args, localArgs, error) {
 	var nrtupdaterArgs nrtupdater.Args
 	var resourcemonitorArgs resourcemonitor.Args
 	var rteArgs resourcetopologyexporter.Args
+	var localArgs localArgs
 
 	usage, err := getUsage()
 	if err != nil {
-		return nrtupdaterArgs, resourcemonitorArgs, rteArgs, err
+		return nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, err
 	}
 
 	arguments, _ := docopt.ParseArgs(usage, argv, fmt.Sprintf("%s %s", ProgramName, "TBD"))
@@ -135,14 +180,14 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourceto
 		if nrtupdaterArgs.Hostname == "" {
 			nrtupdaterArgs.Hostname, err = os.Hostname()
 			if err != nil {
-				return nrtupdaterArgs, resourcemonitorArgs, rteArgs, fmt.Errorf("error getting the host name: %w", err)
+				return nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, fmt.Errorf("error getting the host name: %w", err)
 			}
 		}
 	}
 
 	resourcemonitorArgs.SleepInterval, err = time.ParseDuration(arguments["--sleep-interval"].(string))
 	if err != nil {
-		return nrtupdaterArgs, resourcemonitorArgs, rteArgs, fmt.Errorf("invalid --sleep-interval specified: %w", err)
+		return nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, fmt.Errorf("invalid --sleep-interval specified: %w", err)
 	}
 	if ns, ok := arguments["--watch-namespace"].(string); ok {
 		resourcemonitorArgs.Namespace = ns
@@ -163,7 +208,7 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourceto
 	if refCnt, ok := arguments["--reference-container"].(string); ok {
 		rteArgs.ReferenceContainer, err = resourcetopologyexporter.ContainerIdentFromString(refCnt)
 		if err != nil {
-			return nrtupdaterArgs, resourcemonitorArgs, rteArgs, err
+			return nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, err
 		}
 	}
 	if rteArgs.ReferenceContainer == nil {
@@ -184,7 +229,12 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourceto
 		// empty string is a valid value here, so just keep going
 		rteArgs.TopologyManagerPolicy = tmPolicy
 	}
-	return nrtupdaterArgs, resourcemonitorArgs, rteArgs, nil
+
+	if sysinfoConfigPath, ok := arguments["--resource-config"].(string); ok {
+		localArgs.SysInfoConfigFile = sysinfoConfigPath
+	}
+
+	return nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, nil
 }
 
 func getExcludeListFromConfigMap(configMapPath string) (resourcemonitor.ResourceExcludeList, error) {

--- a/config/examples/resources.json
+++ b/config/examples/resources.json
@@ -1,0 +1,6 @@
+{
+	"reserved_cpus": "0,12",
+	"resource_mapping": {
+		"8086:1520": "intel_sriov_netdevice"
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,13 @@ go 1.16
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
+	github.com/jaypipes/pcidb v0.6.0
 	github.com/k8stopologyawareschedwg/resource-topology-exporter v0.0.0-20210729184402-806588edb85b
+	google.golang.org/grpc v1.35.0
+	k8s.io/kubelet v0.21.0
+	k8s.io/kubernetes v1.21.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 // The k8s "sub-"packages do not have 'semver' compatible versions. Thus, we

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,3 +1,6 @@
 FROM  quay.io/centos/centos:centos7.9.2009
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
+RUN mkdir /etc/resource-topology-exporter-config/
+# initialize with empty content
+RUN echo "{}" > /etc/resource-topology-exporter-config/resources.json
 ENTRYPOINT ["/bin/resource-topology-exporter"]

--- a/pkg/podrescompat/client.go
+++ b/pkg/podrescompat/client.go
@@ -1,0 +1,85 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podrescompat
+
+import (
+	"context"
+	"log"
+
+	"google.golang.org/grpc"
+
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/openshift-kni/resource-topology-exporter/pkg/sysinfo"
+)
+
+type sysinfoClient struct {
+	sysInfoConfig string
+	cli           podresourcesapi.PodResourcesListerClient
+}
+
+func NewSysinfoClientFromLister(cli podresourcesapi.PodResourcesListerClient, sysInfoConfig string) podresourcesapi.PodResourcesListerClient {
+	return &sysinfoClient{
+		cli:           cli,
+		sysInfoConfig: sysInfoConfig,
+	}
+}
+
+func (sc *sysinfoClient) List(ctx context.Context, in *podresourcesapi.ListPodResourcesRequest, opts ...grpc.CallOption) (*podresourcesapi.ListPodResourcesResponse, error) {
+	return sc.cli.List(ctx, in, opts...)
+}
+
+func (sc *sysinfoClient) GetAllocatableResources(ctx context.Context, in *podresourcesapi.AllocatableResourcesRequest, opts ...grpc.CallOption) (*podresourcesapi.AllocatableResourcesResponse, error) {
+	resp, err := sc.cli.GetAllocatableResources(ctx, in, opts...)
+	if err != nil {
+		log.Printf("podresourcesapi GetAllocatableResources() failed with %v - using sysinfo", err)
+		sysResp, sysErr := sc.makeAllocatableResourcesResponse()
+		if sysErr != nil {
+			log.Printf("sysinfo makeAllocatableResourcesResponse failed with %v", sysErr)
+			return resp, err
+		}
+		return sysResp, nil
+	}
+	return resp, nil
+}
+
+func (sc *sysinfoClient) makeAllocatableResourcesResponse() (*podresourcesapi.AllocatableResourcesResponse, error) {
+	sysInfo, err := sysinfo.NewSysinfo(sc.sysInfoConfig)
+	if err != nil {
+		return nil, err
+	}
+	return MakeAllocatableResourcesResponseFromSysInfo(sysInfo), nil
+}
+
+func MakeAllocatableResourcesResponseFromSysInfo(sysInfo sysinfo.SysInfo) *podresourcesapi.AllocatableResourcesResponse {
+	resp := podresourcesapi.AllocatableResourcesResponse{
+		CpuIds: sysInfo.CPUs.ToSliceInt64(),
+	}
+	for resourceName, resourceDevices := range sysInfo.Resources {
+		for numaCellID, numaDevices := range resourceDevices {
+			cntDevs := podresourcesapi.ContainerDevices{
+				ResourceName: resourceName,
+				DeviceIds:    numaDevices,
+				Topology: &podresourcesapi.TopologyInfo{
+					Nodes: []*podresourcesapi.NUMANode{
+						&podresourcesapi.NUMANode{ID: int64(numaCellID)},
+					},
+				},
+			}
+			resp.Devices = append(resp.Devices, &cntDevs)
+		}
+	}
+	return &resp
+}

--- a/pkg/podrescompat/client_test.go
+++ b/pkg/podrescompat/client_test.go
@@ -1,0 +1,67 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podrescompat
+
+import (
+	"reflect"
+	"testing"
+
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	"github.com/openshift-kni/resource-topology-exporter/pkg/sysinfo"
+)
+
+func TestMakeAllocatableResourcesResponseFromSysInfo(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		sysInfo  sysinfo.SysInfo
+		expected *podresourcesapi.AllocatableResourcesResponse
+	}{
+		{
+			"cpus and devices",
+			sysinfo.SysInfo{
+				CPUs: cpuset.MustParse("1-7"),
+				Resources: map[string]sysinfo.PerNUMADevices{
+					"intel_nics": map[int][]string{
+						0: []string{"0000:00:02.0", "0000:00:02.1"},
+					},
+				},
+			},
+			&podresourcesapi.AllocatableResourcesResponse{
+				CpuIds: []int64{1, 2, 3, 4, 5, 6, 7},
+				Devices: []*podresourcesapi.ContainerDevices{
+					&podresourcesapi.ContainerDevices{
+						ResourceName: "intel_nics",
+						DeviceIds:    []string{"0000:00:02.0", "0000:00:02.1"},
+						Topology: &podresourcesapi.TopologyInfo{
+							Nodes: []*podresourcesapi.NUMANode{
+								&podresourcesapi.NUMANode{ID: int64(0)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := MakeAllocatableResourcesResponseFromSysInfo(testCase.sysInfo)
+			if !reflect.DeepEqual(got, testCase.expected) {
+				t.Errorf("got %v, want %v", got, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,0 +1,171 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/jaypipes/ghw/pkg/pci"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+const (
+	SysDevicesOnlineCPUs = "/sys/devices/system/cpu/online"
+)
+
+type Config struct {
+	ReservedCPUs string `json:"reserved_cpus"`
+	// vendor:device -> resourcename
+	ResourceMapping map[string]string `json:"resource_mapping"`
+}
+
+// NUMA Cell -> deviceIDs
+type PerNUMADevices map[int][]string
+
+type SysInfo struct {
+	CPUs cpuset.CPUSet
+	// resource name -> devices
+	Resources map[string]PerNUMADevices
+}
+
+func (si SysInfo) String() string {
+	b := strings.Builder{}
+	fmt.Fprintf(&b, "cpus: %s\n", si.CPUs.String())
+	for resourceName, numaDevs := range si.Resources {
+		fmt.Fprintf(&b, "resource %q:\n", resourceName)
+		for numaNode, devs := range numaDevs {
+			fmt.Fprintf(&b, "  numa cell %d -> %v\n", numaNode, devs)
+		}
+	}
+	return b.String()
+}
+
+func NewSysinfo(configFile string) (SysInfo, error) {
+	sysinfo := SysInfo{}
+	conf, err := readConfig(configFile)
+	if err != nil {
+		return sysinfo, err
+	}
+	log.Printf("conf: received: %+#v", conf)
+
+	sysinfo.CPUs, err = GetCPUResources(conf.ReservedCPUs, GetOnlineCPUs)
+	if sysinfo.CPUs.Size() == 0 {
+		return sysinfo, fmt.Errorf("no allocatable cpus")
+	}
+
+	sysinfo.Resources, err = GetPCIResources(conf.ResourceMapping, GetPCIDevices)
+	if err != nil {
+		return sysinfo, err
+	}
+	return sysinfo, nil
+}
+
+func GetCPUResources(resCPUs string, getCPUs func() (cpuset.CPUSet, error)) (cpuset.CPUSet, error) {
+	reservedCPUs, err := cpuset.Parse(resCPUs)
+	if err != nil {
+		return cpuset.CPUSet{}, err
+	}
+	log.Printf("cpus: reserved %s", reservedCPUs.String())
+
+	cpus, err := getCPUs()
+	if err != nil {
+		return cpuset.CPUSet{}, err
+	}
+	log.Printf("cpus: online %s", cpus.String())
+
+	return cpus.Difference(reservedCPUs), nil
+}
+
+func GetPCIResources(resourceMap map[string]string, getPCIs func() ([]*pci.Device, error)) (map[string]PerNUMADevices, error) {
+	numaResources := make(map[string]PerNUMADevices)
+	devices, err := getPCIs()
+	if err != nil {
+		return numaResources, err
+	}
+
+	for _, dev := range devices {
+		resourceName, ok := ResourceNameForDevice(dev, resourceMap)
+		if !ok {
+			continue
+		}
+
+		numaDevs, ok := numaResources[resourceName]
+		if !ok {
+			numaDevs = make(PerNUMADevices)
+		}
+
+		nodeID := -1
+		if dev.Node != nil {
+			nodeID = dev.Node.ID
+		}
+		numaDevs[nodeID] = append(numaDevs[nodeID], dev.Address)
+		numaResources[resourceName] = numaDevs
+	}
+
+	return numaResources, nil
+}
+
+func ResourceNameForDevice(dev *pci.Device, resourceMap map[string]string) (string, bool) {
+	devID := fmt.Sprintf("%s:%s", dev.Vendor.ID, dev.Product.ID)
+	if resourceName, ok := resourceMap[devID]; ok {
+		log.Printf("devs: resource for %s is %q", devID, resourceName)
+		return resourceName, true
+	}
+	if resourceName, ok := resourceMap[dev.Vendor.ID]; ok {
+		log.Printf("devs: resource for %s is %q", dev.Vendor.ID, resourceName)
+		return resourceName, true
+	}
+	return "", false
+}
+
+func GetOnlineCPUs() (cpuset.CPUSet, error) {
+	data, err := ioutil.ReadFile(SysDevicesOnlineCPUs)
+	if err != nil {
+		return cpuset.CPUSet{}, err
+	}
+	cpus := strings.TrimSpace(string(data))
+	return cpuset.Parse(cpus)
+}
+
+func GetPCIDevices() ([]*pci.Device, error) {
+	info, err := pci.New()
+	if err != nil {
+		return nil, err
+	}
+	return info.Devices, nil
+}
+
+func readConfig(configFile string) (Config, error) {
+	var conf Config
+	src, err := os.Open(configFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("conf: none found")
+			return conf, nil
+		}
+		return conf, err
+	}
+	defer src.Close()
+	err = json.NewDecoder(src).Decode(&conf)
+	log.Printf("conf: decoded: %+#v", conf)
+	return conf, err
+}

--- a/pkg/sysinfo/sysinfo_test.go
+++ b/pkg/sysinfo/sysinfo_test.go
@@ -1,0 +1,165 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jaypipes/ghw/pkg/pci"
+	"github.com/jaypipes/ghw/pkg/topology"
+	"github.com/jaypipes/pcidb"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+func TestGetCPUResources(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		online   string
+		reserved string
+		expected string
+	}{
+		{
+			name:     "no reserved",
+			online:   "0-15",
+			reserved: "",
+			expected: "0-15",
+		},
+		{
+			name:     "using reserved",
+			online:   "0-15",
+			reserved: "0,8",
+			expected: "1-7,9-15",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := GetCPUResources(testCase.reserved, func() (cpuset.CPUSet, error) { return cpuset.Parse(testCase.online) })
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			expectedCPUs := cpuset.MustParse(testCase.expected)
+			if !got.Equals(expectedCPUs) {
+				t.Errorf("got %s, want %s", got, expectedCPUs)
+			}
+		})
+	}
+}
+
+func TestGetPCIResources(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		devs     []*pci.Device
+		resMap   map[string]string
+		expected map[string]PerNUMADevices
+	}{
+		{"no devs", nil, map[string]string{"8086:1520": "intel_nics"}, map[string]PerNUMADevices{}},
+		{
+			"devs no numa",
+			[]*pci.Device{
+				fakePCIDevice("8086", "1520", "0000:00:02.0", -1),
+				fakePCIDevice("8086", "1520", "0000:00:02.1", -1),
+			},
+			map[string]string{"8086:1520": "intel_nics"},
+			map[string]PerNUMADevices{
+				"intel_nics": map[int][]string{
+					-1: []string{"0000:00:02.0", "0000:00:02.1"},
+				},
+			},
+		},
+		{
+			"devs single numa",
+			[]*pci.Device{
+				fakePCIDevice("8086", "1520", "0000:00:02.0", 0),
+				fakePCIDevice("8086", "1520", "0000:00:02.1", 0),
+			},
+			map[string]string{"8086:1520": "intel_nics"},
+			map[string]PerNUMADevices{
+				"intel_nics": map[int][]string{
+					0: []string{"0000:00:02.0", "0000:00:02.1"},
+				},
+			},
+		},
+		{
+			"devs multi numa",
+			[]*pci.Device{
+				fakePCIDevice("8086", "1520", "0000:00:02.0", 0),
+				fakePCIDevice("8086", "1520", "0000:00:03.0", 1),
+			},
+			map[string]string{"8086:1520": "intel_nics"},
+			map[string]PerNUMADevices{
+				"intel_nics": map[int][]string{
+					0: []string{"0000:00:02.0"},
+					1: []string{"0000:00:03.0"},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := GetPCIResources(testCase.resMap, func() ([]*pci.Device, error) { return testCase.devs, nil })
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, testCase.expected) {
+				t.Errorf("got %v, want %v", got, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestResourceNameForDevice(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		dev      *pci.Device
+		resMap   map[string]string
+		expected string
+	}{
+		{"anonymous", namedPCIDevice("", ""), map[string]string{}, ""},
+		{"full match", namedPCIDevice("8086", "1520"), map[string]string{"8086:1520": "intel_nics"}, "intel_nics"},
+		{"vendor match", namedPCIDevice("8086", "1520"), map[string]string{"8086": "intel_nics"}, "intel_nics"},
+		{"full over partial match", namedPCIDevice("8086", "1520"), map[string]string{"8086:1520": "my_nics", "8086": "intel_nics"}, "my_nics"},
+		{"no product match", namedPCIDevice("8086", "1520"), map[string]string{"1520": "my_nics", "8086": "intel_nics"}, "intel_nics"},
+		{"ignore if no resMap", namedPCIDevice("8086", "1520"), map[string]string{}, ""},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, _ := ResourceNameForDevice(testCase.dev, testCase.resMap)
+			if got != testCase.expected {
+				t.Errorf("got %q, want %q", got, testCase.expected)
+			}
+		})
+	}
+}
+
+func namedPCIDevice(vendorID, productID string) *pci.Device {
+	return &pci.Device{
+		Vendor: &pcidb.Vendor{
+			ID: vendorID,
+		},
+		Product: &pcidb.Product{
+			ID: productID,
+		},
+	}
+}
+
+func fakePCIDevice(vendorID, productID, address string, numaNode int) *pci.Device {
+	dev := namedPCIDevice(vendorID, productID)
+	dev.Address = address
+	if numaNode != -1 {
+		dev.Node = &topology.Node{ID: numaNode}
+	}
+	return dev
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,6 +49,7 @@ github.com/googleapis/gnostic/openapiv2
 # github.com/imdario/mergo v0.3.5
 github.com/imdario/mergo
 # github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
+## explicit
 github.com/jaypipes/ghw
 github.com/jaypipes/ghw/pkg/baseboard
 github.com/jaypipes/ghw/pkg/bios
@@ -71,6 +72,7 @@ github.com/jaypipes/ghw/pkg/topology
 github.com/jaypipes/ghw/pkg/unitutil
 github.com/jaypipes/ghw/pkg/util
 # github.com/jaypipes/pcidb v0.6.0
+## explicit
 github.com/jaypipes/pcidb
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
@@ -151,6 +153,7 @@ google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.35.0 => google.golang.org/grpc v1.27.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -426,10 +429,12 @@ k8s.io/component-base/version
 # k8s.io/klog/v2 v2.8.0
 k8s.io/klog/v2
 # k8s.io/kubelet v0.21.0 => k8s.io/kubelet v0.21.0
+## explicit
 k8s.io/kubelet/config/v1beta1
 k8s.io/kubelet/pkg/apis/podresources/v1
 k8s.io/kubelet/pkg/apis/podresources/v1alpha1
 # k8s.io/kubernetes v1.21.0
+## explicit
 k8s.io/kubernetes/pkg/features
 k8s.io/kubernetes/pkg/kubelet/apis/podresources
 k8s.io/kubernetes/pkg/kubelet/cm/cpuset
@@ -444,6 +449,7 @@ sigs.k8s.io/structured-merge-diff/v4/schema
 sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 # golang.org/x/text => golang.org/x/text v0.3.5


### PR DESCRIPTION
The resource topology exporter depends on the full
availability of the podresources API, so with *both*
- List
- GetAllocatableResources

However the latter is feature-gated - being alpha,
and in some environments it could not be enabled,
nor the admin would be willing to enable such feature gate.

It is still worthy to be able to *test* and *benchmark*
RTE in these environments, so for *benchmark purposes*
we add a very limited and very intentionally narrow
emulation of GetAllocatableResources functionality,
reading raw data from the system the same way the kubelet would.

Of course this is intentionally limited and will not
be evolved (barring bugs and extremely simple additions)
because the recommended and supported way is to
just enable the full feature set of the podresources API.

Signed-off-by: Francesco Romani <fromani@redhat.com>