### PR TITLE
make: run unit tests only if we have pkgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ push: image
 
 .PHONY: test-unit
 test-unit:
-	go test ./pkg/...
+	[ -d ./pkg ] && go test ./pkg/... || :
 
 build-e2e: outdir
 	# need to use makefile rules in a better way


### PR DESCRIPTION
If we don't have pkgs in this project - for example
because we vendor everything, there is no point in
running the unit tests.

Signed-off-by: Francesco Romani <fromani@redhat.com>