### PR TITLE
config: unify excludelist and resources config

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -16,8 +16,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"text/template"
@@ -41,7 +41,7 @@ const (
 )
 
 type localArgs struct {
-	SysInfoConfigFile string
+	SysConf sysinfo.Config
 }
 
 func main() {
@@ -53,7 +53,7 @@ func main() {
 	// only for debug purposes
 	// printing the header so early includes any debug message from the sysinfo package
 	log.Printf("=== System information ===\n")
-	sysInfo, err := sysinfo.NewSysinfo(localArgs.SysInfoConfigFile)
+	sysInfo, err := sysinfo.NewSysinfo(localArgs.SysConf)
 	if err != nil {
 		log.Fatalf("failed to query system info: %v", err)
 	}
@@ -66,8 +66,8 @@ func main() {
 	}
 
 	sysCli := k8sCli
-	if localArgs.SysInfoConfigFile != "" {
-		sysCli = podrescompat.NewSysinfoClientFromLister(k8sCli, localArgs.SysInfoConfigFile)
+	if !localArgs.SysConf.IsEmpty() {
+		sysCli = podrescompat.NewSysinfoClientFromLister(k8sCli, localArgs.SysConf)
 	}
 
 	cli, err := podrescli.NewFilteringClientFromLister(sysCli, rteArgs.Debug, rteArgs.ReferenceContainer)
@@ -95,8 +95,7 @@ const helpTemplate string = `{{.ProgramName}}
 			[--kubelet-config-file=<path>]
 			[--topology-manager-policy=<pol>]
 			[--reference-container=<spec>]
-			[--exclude-list-config=<path>]
-			[--resource-config=<path>]
+			[--config=<path>]
 
   {{.ProgramName}} -h | --help
   {{.ProgramName}} --version
@@ -124,11 +123,9 @@ const helpTemplate string = `{{.ProgramName}}
                                   See: https://github.com/kubernetes/kubernetes/issues/102190
                                   format of spec is namespace/podname/containername.
                                   Alternatively, you can use the env vars
-				                  REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.
-  --exclude-list-config=<path>    Exclude resources list file path.
-                                  [Default: /etc/resource-topology-exporter-config/exclude-list-config.yaml]
-  --resource-config=<path>        Resource Mapping configuration file path.
-                                  [Default: /etc/resource-topology-exporter-config/resources.json]`
+                                  REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.
+  --config=<path>                 Configuration file path. Use this to set the exclude list.
+                                  [Default: /etc/resource-topology-exporter/config.yaml]`
 
 func getUsage() (string, error) {
 	var helpBuffer bytes.Buffer
@@ -215,11 +212,13 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourceto
 		rteArgs.ReferenceContainer = resourcetopologyexporter.ContainerIdentFromEnv()
 	}
 
-	if excludeListConfigMapPath, ok := arguments["--exclude-list-config"].(string); ok {
-		resourcemonitorArgs.ExcludeList, err = getExcludeListFromConfigMap(excludeListConfigMapPath)
+	if configPath, ok := arguments["--config"].(string); ok {
+		conf, err := readConfig(configPath)
 		if err != nil {
-			log.Fatalf("error getting exclude list from the configutarion: %v", err)
+			log.Fatalf("error reading the configuration file: %v", err)
 		}
+		resourcemonitorArgs.ExcludeList.ExcludeList = conf.ExcludeList
+		localArgs.SysConf = conf.Resources
 	}
 	if tmPolicy, ok := arguments["--topology-manager-policy"].(string); ok {
 		if tmPolicy == "" {
@@ -230,29 +229,25 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourceto
 		rteArgs.TopologyManagerPolicy = tmPolicy
 	}
 
-	if sysinfoConfigPath, ok := arguments["--resource-config"].(string); ok {
-		localArgs.SysInfoConfigFile = sysinfoConfigPath
-	}
-
 	return nrtupdaterArgs, resourcemonitorArgs, rteArgs, localArgs, nil
 }
 
-func getExcludeListFromConfigMap(configMapPath string) (resourcemonitor.ResourceExcludeList, error) {
-	excludeList := resourcemonitor.ResourceExcludeList{}
+type config struct {
+	ExcludeList map[string][]string
+	Resources   sysinfo.Config
+}
 
-	config, err := ioutil.ReadFile(configMapPath)
+func readConfig(configPath string) (config, error) {
+	conf := config{}
+	data, err := os.ReadFile(configPath)
 	if err != nil {
-		// ConfigMap is optional
-		if os.IsNotExist(err) {
-			log.Printf("Info: couldn't find configuration under %v", configMapPath)
-			return excludeList, nil
+		// config is optional
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("Info: couldn't find configuration in %q", configPath)
+			return conf, nil
 		}
-		return excludeList, err
+		return conf, err
 	}
-
-	err = yaml.Unmarshal(config, &excludeList)
-	if err != nil {
-		return excludeList, err
-	}
-	return excludeList, nil
+	err = yaml.Unmarshal(data, &conf)
+	return conf, err
 }

--- a/config/examples/resources.json
+++ b/config/examples/resources.json
@@ -1,6 +1,0 @@
-{
-	"reserved_cpus": "0,12",
-	"resource_mapping": {
-		"8086:1520": "intel_sriov_netdevice"
-	}
-}

--- a/config/examples/rte.yaml
+++ b/config/examples/rte.yaml
@@ -1,0 +1,9 @@
+resources:
+  reservedcpus: "0"
+  resourcemapping:
+    "8086:1520": "intel_sriov_netdevice"
+excludelist:
+  masternode: [memory, device/exampleA]
+  workernode1: [memory, device/exampleB]
+  workernode2: [cpu]
+  "*": [device/exampleC]

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,5 @@
 FROM  quay.io/centos/centos:centos7.9.2009
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
-RUN mkdir /etc/resource-topology-exporter-config/
-# initialize with empty content
-RUN echo "{}" > /etc/resource-topology-exporter-config/resources.json
+RUN mkdir /etc/resource-topology-exporter/ && \
+    touch /etc/resource-topology-exporter/config.yaml
 ENTRYPOINT ["/bin/resource-topology-exporter"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,48 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift-kni/resource-topology-exporter/pkg/sysinfo"
+)
+
+type Config struct {
+	ExcludeList           map[string][]string
+	Resources             sysinfo.Config
+	TopologyManagerPolicy string
+}
+
+func ReadConfig(configPath string) (Config, error) {
+	conf := Config{}
+	// TODO modernize using os.ReadFile
+	data, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		// config is optional
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("Info: couldn't find configuration in %q", configPath)
+			return conf, nil
+		}
+		return conf, err
+	}
+	err = yaml.Unmarshal(data, &conf)
+	return conf, err
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,80 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestReadNonExistent(t *testing.T) {
+	cfg, err := ReadConfig("/does/not/exist")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if cfg.ExcludeList != nil || !cfg.Resources.IsEmpty() || cfg.TopologyManagerPolicy != "" {
+		t.Errorf("unexpected data: %#v", cfg)
+	}
+}
+
+func TestReadMalformed(t *testing.T) {
+	_, err := ReadConfig("/etc/services")
+	if err == nil {
+		t.Errorf("unexpected success reading unrelated data")
+	}
+}
+
+func TestReadValidData(t *testing.T) {
+	content := []byte(testData)
+	tmpfile, err := ioutil.TempFile("", "testrteconfig")
+	if err != nil {
+		t.Errorf("creating tempfile: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write(content); err != nil {
+		t.Errorf("writing content into tempfile: %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Errorf("closing the tempfile: %v", err)
+	}
+	cfg, err := ReadConfig(tmpfile.Name())
+	if err != nil {
+		t.Errorf("unexpected error reading back the config: %v", err)
+	}
+	if cfg.TopologyManagerPolicy != "restricted" {
+		t.Errorf("unexpected values: %#v", cfg)
+	}
+	if cfg.Resources.ReservedCPUs != "0" {
+		t.Errorf("unexpected values: %#v", cfg)
+	}
+	if cfg.Resources.ResourceMapping["8086:1520"] != "intel_sriov_netdevice" {
+		t.Errorf("unexpected values: %#v", cfg)
+	}
+	if cfg.ExcludeList["masternode"][0] != "memory" {
+		t.Errorf("unexpected values: %#v", cfg)
+	}
+}
+
+const testData string = `resources:
+  reservedcpus: "0"
+  resourcemapping:
+    "8086:1520": "intel_sriov_netdevice"
+topologymanagerpolicy: "restricted"
+excludelist:
+  masternode: [memory, device/exampleA]
+  workernode1: [memory, device/exampleB]
+  workernode2: [cpu]`

--- a/pkg/podrescompat/client.go
+++ b/pkg/podrescompat/client.go
@@ -26,14 +26,14 @@ import (
 )
 
 type sysinfoClient struct {
-	sysInfoConfig string
-	cli           podresourcesapi.PodResourcesListerClient
+	sysConf sysinfo.Config
+	cli     podresourcesapi.PodResourcesListerClient
 }
 
-func NewSysinfoClientFromLister(cli podresourcesapi.PodResourcesListerClient, sysInfoConfig string) podresourcesapi.PodResourcesListerClient {
+func NewSysinfoClientFromLister(cli podresourcesapi.PodResourcesListerClient, sysConf sysinfo.Config) podresourcesapi.PodResourcesListerClient {
 	return &sysinfoClient{
-		cli:           cli,
-		sysInfoConfig: sysInfoConfig,
+		cli:     cli,
+		sysConf: sysConf,
 	}
 }
 
@@ -56,7 +56,7 @@ func (sc *sysinfoClient) GetAllocatableResources(ctx context.Context, in *podres
 }
 
 func (sc *sysinfoClient) makeAllocatableResourcesResponse() (*podresourcesapi.AllocatableResourcesResponse, error) {
-	sysInfo, err := sysinfo.NewSysinfo(sc.sysInfoConfig)
+	sysInfo, err := sysinfo.NewSysinfo(sc.sysConf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Unify the two configuration file in just one, moving
the resource specification from JSON to YAML in the process.
This allows us to easily replace the configuration
with just one file - hence with just one config map.

Signed-off-by: Francesco Romani <fromani@redhat.com>