### PR TITLE
Add release lane

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: CI release flow
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: set release version env var
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: resource-topology-exporter
+          tags: ${{ env.RELEASE_VERSION}}
+          dockerfiles: |
+            ./images/Dockerfile
+
+      - name: push to quay
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/openshift-kni
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_ROBOTOKEN }}
+
+      - name: print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
From now on, for every new tag we'll build and push an image to quay based on that tag.
There is no need with testing the image since the openshift CI covers that for us.
We can also trigger the building manually from the Actions tab.

This workflow inspired by the work that was done in: https://github.com/k8stopologyawareschedwg/deployer/blob/main/.github/workflows/release.yml

Signed-off-by: Talor Itzhak <titzhak@redhat.com>