### PR TITLE
Dockerfile: use ubi8 images

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM  quay.io/centos/centos:centos7.9.2009
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml


### PR DESCRIPTION
We need to build images consistently with what the OCP CI does,
so let's switch from centos7 to ubi8:
https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image

Signed-off-by: Francesco Romani <fromani@redhat.com>