### PR TITLE
images: ensure pciutils

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,4 +2,5 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml
+RUN microdnf install pciutils
 ENTRYPOINT ["/bin/resource-topology-exporter"]

--- a/images/Dockerfile.openshift
+++ b/images/Dockerfile.openshift
@@ -14,4 +14,5 @@ FROM registry.access.redhat.com/ubi8/ubi
 COPY --from=builder /go/src/github.com/openshift-kni/resource-topology-exporter/_out/resource-topology-exporter /bin/resource-topology-exporter
 RUN mkdir /etc/resource-topology-exporter/ && \
     touch /etc/resource-topology-exporter/config.yaml
+RUN dnf install pciutils
 ENTRYPOINT ["/bin/resource-topology-exporter"]


### PR DESCRIPTION
We need to make sure we have the PCI id database installed
in the runtime image. The simplest way to do so is to install
the pciutils package when creating the image.

Signed-off-by: Francesco Romani <fromani@redhat.com>