### PR TITLE
CI: Refactoring deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ test-e2e: binaries build-e2e
 .PHONY: test-e2e-full
 	go test -v ./test/e2e/
 
+# a specific target for running e2e tests under the KNI's CI
+# this assumes to be running on a vanilla OCP cluster
+.PHONY: test-e2e-kni
+test-e2e-kni: build-e2e
+	hack/e2e-kni.sh
+
 .PHONY: deploy
 deploy:
 	hack/deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build-e2e: outdir
 
 .PHONY: test-e2e
 test-e2e: binaries build-e2e
-	_out/rte-e2e.test
+	_out/rte-e2e.test -ginkgo.focus='\[TopologyUpdater\]*'
 
 .PHONY: test-e2e-full
 	go test -v ./test/e2e/

--- a/hack/kube-update.sh
+++ b/hack/kube-update.sh
@@ -5,7 +5,7 @@ set -e
 # expect oc to be in PATH by default
 OC_TOOL="${OC_TOOL:-oc}"
 
-echo "Update Kubelet with necessary configuration for RTE deployment"
+echo "Updating Kubelet with necessary configuration for RTE deployment"
 cat << EOF | oc apply -f -
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig

--- a/hack/run-e2e-kni.sh
+++ b/hack/run-e2e-kni.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xue
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+BASE_DIR="$(dirname "$(realpath "$0")")"
+PROJECT_DIR="${BASE_DIR}"/..
+
+RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
+E2E_NAMESPACE_NAME="${E2E_NAMESPACE_NAME:-rte-e2e}"
+E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-SingleNUMANodeContainerLevel}"
+
+make -C "${PROJECT_DIR}" kube-update
+make -C "${PROJECT_DIR}" wait-for-mcp
+echo "Kubelet configured properly"
+
+RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}" "${BASE_DIR}"/setup-e2e.sh
+make -C "${PROJECT_DIR}" test-e2e

--- a/hack/setup-e2e.sh
+++ b/hack/setup-e2e.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -xue
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+RTE_CONTAINER_IMAGE="${RTE_CONTAINER_IMAGE:-quay.io/openshift-kni/resource-topology-exporter:4.9-snapshot}"
+RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
+
+echo "Deploying using image $RTE_CONTAINER_IMAGE."
+
+echo "Create $RTE_NAMESPACE namespace"
+cat << EOF | "$OC_TOOL" apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "$RTE_NAMESPACE"
+EOF
+
+echo "Create RTE config file"
+cat << EOF | "$OC_TOOL" apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rte-config
+  namespace: ${RTE_NAMESPACE}
+data:
+  config.yaml: |
+    resources:
+      reservedcpus: "0,1"
+EOF
+
+RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE} \
+RTE_POLL_INTERVAL=10s \
+RTE_NAMESPACE=${RTE_NAMESPACE} \
+RTE_CONFIG_FILE=/etc/resource-topology-exporter/config.yaml \
+TOPOLOGY_MANAGER_POLICY=single-numa-node \
+make gen-manifests | tee rte.yaml
+
+echo "Create CRD"
+$OC_TOOL create -f manifests/crd.yaml
+
+echo "Deploy RTE"
+$OC_TOOL adm policy add-scc-to-user privileged system:serviceaccount:"$RTE_NAMESPACE":rte-account
+$OC_TOOL create -f rte.yaml
+
+echo "Output cluster info"
+$OC_TOOL get nodes
+$OC_TOOL get pods -A
+$OC_TOOL describe pod -l name=resource-topology || :
+$OC_TOOL logs -l name=resource-topology -c resource-topology-exporter-container || :
+
+echo "Check that cluster is ready"
+hack/check-ds.sh "$OC_TOOL" "$RTE_NAMESPACE"
+$OC_TOOL logs -l name=resource-topology -c resource-topology-exporter-container || :
+$OC_TOOL get noderesourcetopologies.topology.node.k8s.io -A -o yaml
+
+echo "Cluster is ready!"

--- a/hack/teardown-e2e.sh
+++ b/hack/teardown-e2e.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xue
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
+
+echo "Undeploy RTE"
+"$OC_TOOL" delete clusterrolebinding handle-rte
+"$OC_TOOL" delete clusterrole rte-handler
+"$OC_TOOL" delete ns "${RTE_NAMESPACE}"
+
+echo "Delete CRD"
+"$OC_TOOL" delete -f manifests/crd.yaml


### PR DESCRIPTION
- Move all necessary env variables inside the run-e2e-kni.sh script instead of defining them directly in the release configuration:
  https://github.com/openshift/release/blob/master/ci-operator/config/openshift-kni/resource-topology-exporter/openshift-kni-resource-topology-exporter-master.yaml#L47
  which is less flexible and will force breaking changes in case of variables update.

- Add an explicit make target for our CI which is not relevant for the K8s cluster, hence the kni in the name.

- Rename the scripts to explicitly point out that it is for test porpuses and not a general way to deploy the componenets:
  ```deploy.sh``` -> ```setup-e2e.sh```
  ```undeploy.sh``` -> ```teardown-e2e.sh```

I'm leaving the old scripts and making targets just for the CI to pass.
Later I'll issue a PR under the release repo in order to test the new changes.
Only after CI stabilization, we'll remove the dead scripts.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>