### PR TITLE
CI: Fixing the scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-e2e: binaries build-e2e
 # this assumes to be running on a vanilla OCP cluster
 .PHONY: test-e2e-kni
 test-e2e-kni: build-e2e
-	hack/e2e-kni.sh
+	hack/run-e2e-kni.sh
 
 .PHONY: deploy
 deploy:

--- a/hack/run-e2e-kni.sh
+++ b/hack/run-e2e-kni.sh
@@ -11,6 +11,7 @@ PROJECT_DIR="${BASE_DIR}"/..
 export RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
 export E2E_NAMESPACE_NAME="${E2E_NAMESPACE_NAME:-rte-e2e}"
 export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-single-numa-node}"
+export RTE_CONTAINER_IMAGE="${RTE_CONTAINER_IMAGE}"
 
 make -C "${PROJECT_DIR}" kube-update
 make -C "${PROJECT_DIR}" wait-for-mcp

--- a/hack/run-e2e-kni.sh
+++ b/hack/run-e2e-kni.sh
@@ -8,13 +8,13 @@ OC_TOOL="${OC_TOOL:-oc}"
 BASE_DIR="$(dirname "$(realpath "$0")")"
 PROJECT_DIR="${BASE_DIR}"/..
 
-RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
-E2E_NAMESPACE_NAME="${E2E_NAMESPACE_NAME:-rte-e2e}"
-E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-single-numa-node}"
+export RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
+export E2E_NAMESPACE_NAME="${E2E_NAMESPACE_NAME:-rte-e2e}"
+export E2E_TOPOLOGY_MANAGER_POLICY="${E2E_TOPOLOGY_MANAGER_POLICY:-single-numa-node}"
 
 make -C "${PROJECT_DIR}" kube-update
 make -C "${PROJECT_DIR}" wait-for-mcp
 echo "Kubelet configured properly"
 
-RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}" "${BASE_DIR}"/setup-e2e.sh
+"${BASE_DIR}"/setup-e2e.sh
 make -C "${PROJECT_DIR}" test-e2e

--- a/hack/setup-e2e.sh
+++ b/hack/setup-e2e.sh
@@ -4,8 +4,9 @@ set -xue
 
 # expect oc to be in PATH by default
 OC_TOOL="${OC_TOOL:-oc}"
-RTE_CONTAINER_IMAGE="${RTE_CONTAINER_IMAGE:-quay.io/openshift-kni/resource-topology-exporter:4.9-snapshot}"
 RTE_NAMESPACE="${RTE_NAMESPACE:-rte-e2e}"
+# mention explicitly to avoid from running tests with obsolete version
+RTE_CONTAINER_IMAGE="${RTE_CONTAINER_IMAGE}"
 
 echo "Deploying using image $RTE_CONTAINER_IMAGE."
 


### PR DESCRIPTION
- Wrong script name in the make target 
- Export all the variables so child processes will have them as well
- Having the test running with some default RTE_CONTAINER_IMAGE is usually useless since it doesn't contain the latest changes, but yet the CI will run and we might think that everything is ok.
The test will failed at the beginning if the RTE_CONTAINER_IMAGE won't be mention explicitly

Signed-off-by: Talor Itzhak <titzhak@redhat.com>