### PR TITLE
read topology manager scope from conf file

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -175,6 +175,11 @@ func parseArgs(args ...string) (ProgArgs, error) {
 		pArgs.RTE.TopologyManagerPolicy = conf.TopologyManagerPolicy
 	}
 
+	// overwrite if explicitly mentioned in conf
+	if conf.TopologyManagerScope != "" {
+		pArgs.RTE.TopologyManagerScope = conf.TopologyManagerScope
+	}
+
 	return pArgs, nil
 }
 

--- a/cmd/resource-topology-exporter/main_test.go
+++ b/cmd/resource-topology-exporter/main_test.go
@@ -94,5 +94,26 @@ func (s *ArgsParseTestSuite) TestArgsParse() {
 			// compare the default values from the file with the output from the parseArgs function
 			So(string(pArgsAsJson), ShouldResemble, string(expected))
 		})
+
+		Convey("should take topology policy and scope and from config", func() {
+			content := []byte(testData)
+			tmpfile, err := ioutil.TempFile("", "testrteconfig")
+			So(err, ShouldBeNil)
+
+			defer os.Remove(tmpfile.Name())
+
+			err = ioutil.WriteFile(tmpfile.Name(), content, 0644)
+			So(err, ShouldBeNil)
+
+			pArgs, err := parseArgs(fmt.Sprintf("--config=%s", tmpfile.Name()))
+			So(err, ShouldBeNil)
+
+			So(pArgs.RTE.TopologyManagerPolicy, ShouldEqual, "restricted")
+			So(pArgs.RTE.TopologyManagerScope, ShouldEqual, "pod")
+		})
 	})
 }
+
+const testData string = `
+topologymanagerpolicy: "restricted"
+topologymanagerscope: "pod"`


### PR DESCRIPTION
In case the topology manager scope is configured in the conf file we should read the value from it instead of the default.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>